### PR TITLE
fix(format): clear pre-existing prettier violations in src/pages/index.astro

### DIFF
--- a/smd-web/src/pages/index.astro
+++ b/smd-web/src/pages/index.astro
@@ -33,9 +33,8 @@ function stageLabel(stage: string): string {
       <p>
         Scott is a product builder who has spent two decades shipping enterprise
         software - from hands-on engineering through leading product and
-        platform teams at scale. He worked on complex systems,
-        learning firsthand what it takes to get software from idea to paying
-        customers.
+        platform teams at scale. He worked on complex systems, learning
+        firsthand what it takes to get software from idea to paying customers.
       </p>
       <p>
         He now runs SMDurgan, a venture studio where small, focused products are


### PR DESCRIPTION
## Summary

Unblocks the smd-web build, which has been failing on \`format:check\` since 2026-02-19 due to a prettier violation in \`src/pages/index.astro\`.

## Background

Discovered while preparing venturecrane/smd-console#3 (the Cloudflare Pages deploy commit-message sanitizer port). That PR cannot pass CI because the build job has been red on main for ~7 weeks - prettier reports formatting issues in this file, and \`format:check\` exits non-zero before the rest of the build runs.

## The fix

\`prettier --write smd-web/src/pages/index.astro\`. Mechanical - no semantic change. The only edit is rewrapping a sentence to fit the configured print width.

\`\`\`diff
-        platform teams at scale. He worked on complex systems,
-        learning firsthand what it takes to get software from idea to paying
-        customers.
+        platform teams at scale. He worked on complex systems, learning
+        firsthand what it takes to get software from idea to paying customers.
\`\`\`

## Validation

- \`npm run format:check\` is now clean (was failing on exactly this file)
- 1 file changed, 2 insertions(+), 3 deletions(-)

## Test plan

- [ ] CI build passes (was the pre-existing blocker)
- [ ] Lighthouse passes
- [ ] Deploy job passes (this is the first deploy attempt to main since 2026-02-19)