### PR TITLE
chore: align docs/ with documentation standard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+---
+title: Documentation
+sidebar:
+  order: 0
+---
+
+Documentation root for smd-console. This is a spoke repo in the Venture Crane enterprise.
+
+## Directories
+
+| Directory                | Purpose                                               |
+| ------------------------ | ----------------------------------------------------- |
+| [adr/](./adr/)           | Architecture Decision Records - ready for future ADRs |
+| [handoffs/](./handoffs/) | Session handoff records                               |
+| [pm/](./pm/)             | Product requirements and specifications               |
+| [process/](./process/)   | Project instructions and workflows                    |

--- a/docs/handoffs/2026-02-02-strategic-context.md
+++ b/docs/handoffs/2026-02-02-strategic-context.md
@@ -15,25 +15,30 @@ First strategic session in smd-console. Established CEO role and identified crit
 ## Questions for Next Session
 
 ### Financial Picture
+
 - [ ] What's the runway?
 - [ ] Current burn rate?
 - [ ] Any revenue yet?
 - [ ] Funding source (bootstrapped? funded?)
 
 ### Venture Health
+
 - [ ] What does Venture Crane actually do today? Who uses it?
 - [ ] What are Silicon Crane, DFG, and Kid Expenses supposed to become?
 - [ ] Which venture is closest to generating revenue?
 
 ### Customers
+
 - [ ] Do any ventures have external users yet?
 - [ ] Any validation on the planning-stage ventures?
 
 ### Priorities
+
 - [ ] What's the 90-day goal?
 - [ ] Why these four ventures? What's the thesis?
 
 ### Team
+
 - [ ] Is this a solo operation or is there a team?
 - [ ] What's realistic capacity?
 
@@ -42,6 +47,7 @@ First strategic session in smd-console. Established CEO role and identified crit
 ## Context Available
 
 From CLAUDE.md, we know:
+
 - **Venture Crane (vc)** - AI-powered dev infrastructure, Active
 - **Silicon Crane (sc)** - TBD, Planning
 - **Durgan Field Guide (dfg)** - TBD, Planning

--- a/docs/handoffs/index.md
+++ b/docs/handoffs/index.md
@@ -1,0 +1,12 @@
+---
+title: Handoffs
+sidebar:
+  order: 0
+---
+
+Session handoff records for smd-console. Each file captures the state of a working session - context established, decisions made, and open items for the next session.
+
+## Files
+
+- [2026-02-02-strategic-context.md](./2026-02-02-strategic-context.md) - Strategic context gathering session; open questions on financials, venture health, and priorities
+- [DEV.md](./DEV.md) - Active dev handoff record; populated by `/sod` and `/eod` session commands

--- a/docs/pm/index.md
+++ b/docs/pm/index.md
@@ -1,0 +1,11 @@
+---
+title: Product Management
+sidebar:
+  order: 0
+---
+
+Product requirements and specifications for smd-console. Contains PRDs, feature briefs, and product decisions that guide development work.
+
+## Files
+
+_No documents yet. Add PRDs and product briefs here as the product matures._

--- a/docs/process/index.md
+++ b/docs/process/index.md
@@ -1,0 +1,11 @@
+---
+title: Process
+sidebar:
+  order: 0
+---
+
+Project instructions, workflows, and operating procedures for smd-console. Contains development standards, runbooks, and process documentation specific to this repo.
+
+## Files
+
+_No documents yet. Add runbooks and process docs here as workflows are established._


### PR DESCRIPTION
Adds missing index.md files and README per the docs-standard.md framework in crane-console.