### PR TITLE
fix: remove QA grading artifacts

### DIFF
--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -1,0 +1,428 @@
+# /orchestrate - Fleet Sprint Orchestrator
+
+Dispatches coding tasks across fleet machines using `crane` headless mode, monitors progress, and collects results. Extends `/sprint` (single-machine, local worktrees) to multi-machine fleet execution.
+
+> **When to use fleet vs local?** See `docs/fleet-decision-framework.md` for the decision matrix.
+
+## Arguments
+
+```
+/orchestrate <issue numbers> --repo <org/repo> [--venture <code>] [--dry-run] [--resume <sprint_id>]
+```
+
+- Issue numbers: space or comma-separated, `#` prefix optional
+- `--repo <org/repo>`: target repository (required)
+- `--venture <code>`: venture code (default: detect from repo name)
+- `--dry-run`: show dispatch plan only, do not execute
+- `--resume <sprint_id>`: resume a previous orchestration
+
+Parse `$ARGUMENTS`:
+
+1. Split on whitespace and commas
+2. Strip `#` prefix from any token
+3. Extract `--repo <value>` (required)
+4. Extract `--venture <value>` (optional)
+5. Extract `--dry-run` flag if present
+6. Extract `--resume <sprint_id>` if present
+7. Remaining tokens are issue numbers (must be positive integers)
+
+If `--resume` is provided, skip to the Resume Logic section.
+
+If no issue numbers remain after parsing (and no `--resume`), display usage and stop:
+
+```
+Usage: /orchestrate <issue numbers> --repo <org/repo> [--venture <code>] [--dry-run] [--resume <sprint_id>]
+
+Examples:
+  /orchestrate 42 45 51 --repo venturecrane/dc-console
+  /orchestrate 42 45 --repo venturecrane/dc-console --dry-run
+  /orchestrate --resume sprint_01ABC123
+```
+
+Store: `ISSUE_NUMBERS` (array), `REPO` (string), `VENTURE` (string), `DRY_RUN` (bool), `RESUME_ID` (string or null).
+
+## Execution
+
+### DISPATCH Phase
+
+#### Step 1: Fetch and Analyze Issues
+
+For each issue number, fetch via:
+
+```bash
+gh issue view {N} --repo {REPO} --json number,title,body,labels,state
+```
+
+**CRITICAL**: Make all `gh issue view` calls in parallel.
+
+For each issue, extract from labels:
+
+- **Priority**: `prio:*` label (P0/P1/P2/P3)
+- **Component**: `component:*` label
+
+Also extract dependencies from body (same logic as `/sprint`):
+
+- `depends on #N`, `blocked by #N`, `after #N`, `requires #N`
+
+**Validation:**
+
+- If any issue does not exist, stop: `Issue #{N} not found in {REPO}. Aborting.`
+- If any issue has `state: closed`, stop: `Issue #{N} is closed. Remove it and re-run.`
+
+Display issue summary table.
+
+#### Step 2: Build Wave Plan
+
+Same wave planning logic as `/sprint`:
+
+- Extract explicit dependencies
+- Schedule waves respecting dependencies and MAX_CONCURRENT per machine
+- Detect cycles
+
+For fleet orchestration, MAX_CONCURRENT per wave is the sum of available machine slots (see Step 3).
+
+#### Step 2b: Pre-flight CI Check
+
+Before dispatching any tasks, verify CI passes on `origin/main`. SSH to one healthy fleet machine and run the verify command in a temporary worktree:
+
+```bash
+ssh {machine} "cd ~/dev/{REPO_NAME} && git fetch origin main 2>&1 && git worktree add /tmp/preflight-$$ origin/main 2>/dev/null && cd /tmp/preflight-$$ && npm ci --prefer-offline > /dev/null 2>&1 && {VERIFY_COMMAND}; EXIT=$?; cd ~/dev/{REPO_NAME} && git worktree remove --force /tmp/preflight-$$ 2>/dev/null; exit $EXIT"
+```
+
+If the verify command fails, display the failures and ask the Captain using AskUserQuestion:
+
+**"CI is broken on main. Fix first, or override and dispatch anyway?"**
+
+Options: "Fix first (abort)" / "Override and dispatch"
+
+- **Fix first**: Stop orchestration. Display: `CI broken on main. Fix before dispatching.`
+- **Override**: Continue with a warning: `Warning: Dispatching despite CI failures on main. Agents may encounter pre-existing failures.`
+
+#### Step 2c: Shared-File Overlap Detection
+
+After fetching issues, scan issue bodies for file path references (patterns like `src/...`, `*.css`, `*.ts` paths). Also check if issue titles/bodies mention the same component names.
+
+If 2+ issues in the same wave reference the same file, display a warning:
+
+```
+Warning: Potential merge conflict risk
+  - {filename} referenced by #{A}, #{B}
+Consider: Merge in order of fewest shared-file touches first, or split into separate waves.
+```
+
+This is advisory - it does not block dispatch.
+
+#### Step 3: Fleet Health Check and Machine Assignment
+
+**Available machines** (orchestrator host mac23 excluded from worker pool by default):
+
+| Hostname | Max Concurrent |
+| -------- | -------------- |
+| m16      | 3              |
+| mini     | 2              |
+| mbp27    | 2              |
+| think    | 1              |
+
+For each machine, run a health check via `crane_fleet_dispatch` dry-run equivalent:
+
+```bash
+ssh -o ConnectTimeout=5 -o BatchMode=yes {machine} "echo ok && df -BG / | awk 'NR==2{print \$4}'"
+```
+
+Exclude unhealthy machines. If no machines are healthy, stop:
+
+```
+No healthy fleet machines available. Fix connectivity and retry.
+```
+
+**Check reliability scores:**
+
+Read `~/.crane/fleet-reliability.json` (if it exists) and compute each machine's success rate: `successes / dispatches * 100`. Machines below 70% success rate are deprioritized - assign them work only when higher-reliability machines are full. Display scores alongside health status.
+
+**Assign issues to machines:**
+
+Round-robin across healthy machines, respecting per-machine concurrency limits and reliability scores. Priority order: P0 first, then P1, P2, P3. Prefer machines with higher reliability scores.
+
+Display the assignment plan:
+
+```
+Fleet Dispatch Plan:
+
+Wave 1:
+  #{45} [P0] Fix balance calc -> m16
+  #{42} [P1] Add expense filter -> mini
+  #{47} [P2] Update docs -> mbp27
+
+Wave 2 (after Wave 1 merges):
+  #{48} [P1] Refactor auth -> m16
+
+Machines: 3 healthy (m16: 1/3, mini: 1/2, mbp27: 1/2)
+```
+
+#### Step 4: Write Sprint Cache
+
+Generate a sprint ID: `sprint_{ULID-style}` (use `crypto.randomUUID()` to generate).
+
+Write to `~/.crane/sprints/{id}.json`:
+
+```json
+{
+  "id": "sprint_abc123",
+  "venture": "dc",
+  "repo": "venturecrane/dc-console",
+  "current_wave": 1,
+  "wave_plan": [[42, 45, 47], [48]],
+  "dispatched": {},
+  "created_at": "2026-02-20T10:00:00Z",
+  "updated_at": "2026-02-20T10:00:00Z"
+}
+```
+
+#### Step 5: Captain Approval
+
+If `DRY_RUN` is true, stop: `Dry run complete. Re-run without --dry-run to execute.`
+
+Ask the user using AskUserQuestion:
+
+**"Execute Wave {N}? ({count} tasks across {machine_count} machines)"**
+
+Options: "Execute" / "Abort"
+
+If Abort, stop: `Orchestration aborted.`
+
+#### Step 6: Dispatch
+
+For each issue in the current wave, call `crane_fleet_dispatch`:
+
+```
+crane_fleet_dispatch({
+  machine: "{assigned_machine}",
+  venture: "{VENTURE}",
+  repo: "{REPO}",
+  issue_number: {N},
+  branch_name: "{issue-number}-{slugified-title}"
+})
+```
+
+Branch naming follows the same convention as `/sprint`: `{issue-number}-{slugified-title}`, truncated to 50 chars.
+
+**CRITICAL**: Make all `crane_fleet_dispatch` calls in parallel (one message).
+
+Update the sprint cache with dispatch metadata:
+
+```json
+{
+  "dispatched": {
+    "42": { "machine": "m16", "task_id": "task_abc123" },
+    "45": { "machine": "mini", "task_id": "task_def456" }
+  }
+}
+```
+
+Display: `Wave {N} dispatched. Entering monitor loop.`
+
+### MONITOR Phase
+
+Poll loop with exponential backoff: start at 30s, max 5 min, back off when no status changes detected.
+
+For each dispatched task in the current wave:
+
+```
+crane_fleet_status({
+  machine: "{machine}",
+  task_id: "{task_id}"
+})
+```
+
+**CRITICAL**: Make all `crane_fleet_status` calls in parallel.
+
+Track status transitions:
+
+- `running` -> continue monitoring
+- `success` (result.json has `status: success`) -> task complete
+- `failed` (result.json has `status: failed`) -> task failed
+- `crashed` (PID dead, no result.json) -> task failed
+- `not_found` -> warn, continue checking
+
+**Stuck detection**: If a task has been running for >10 minutes with no result.json, flag it:
+
+```
+Warning: Task {task_id} on {machine} for issue #{N} has been running for {minutes}min. Potentially stuck.
+```
+
+Display progress on each poll:
+
+```
+Monitor [2min elapsed]:
+  #{42} on m16: running (5min)
+  #{45} on mini: success - PR #260
+  #{47} on mbp27: running (3min)
+```
+
+Loop until all tasks are terminal (success, failed, or crashed) or Captain intervenes.
+
+### COLLECT Phase
+
+#### Step 1: PR Status Check
+
+For successful tasks, get PR and CI status:
+
+```
+crane_fleet_status({
+  repo: "{REPO}",
+  issue_numbers: [{successful_issue_numbers}]
+})
+```
+
+Display PR summary:
+
+```
+Results:
+
+| #   | Title              | Status  | PR    | CI      |
+| --- | ------------------ | ------- | ----- | ------- |
+| 42  | Fix balance calc   | SUCCESS | #260  | passing |
+| 45  | Add expense filter | SUCCESS | #261  | pending |
+| 47  | Update docs        | FAILED  | -     | -       |
+```
+
+#### Step 1b: Record Reliability Outcomes
+
+For each task in the wave, record its outcome for machine reliability tracking. Update `~/.crane/fleet-reliability.json` by reading the file, incrementing the appropriate counter for the machine, and writing it back:
+
+- Task succeeded (has result.json with `status: success`) -> increment `successes`
+- Task failed (has result.json with `status: failed`) -> increment `failures`
+- Task crashed (PID dead, no result.json) -> increment `crashes`
+
+This data feeds back into Step 3 of the DISPATCH phase for future sprints.
+
+#### Step 2: Handle Failures
+
+For each failed task, ask the user using AskUserQuestion:
+
+**"Issue #{N} failed: {reason}. Retry or skip?"**
+
+Options: "Retry" / "Skip"
+
+- **Retry**: Call `crane_fleet_dispatch` again for this issue on the same machine (or a different one if the original is unhealthy). Max 1 retry per issue. Update sprint cache.
+- **Skip**: Mark as skipped, continue.
+
+If retrying, loop back to MONITOR for just the retried tasks.
+
+#### Step 3: Captain Merge Approval
+
+Once all PRs have passing CI (or Captain decides to proceed), ask:
+
+**"Merge {N} PRs? (squash merge in dependency order)"**
+
+Options: "Merge all" / "Select which to merge" / "Skip merge"
+
+- **Merge all**: For each successful PR in dependency order:
+
+  ```bash
+  gh pr merge {PR_NUMBER} --repo {REPO} --squash
+  ```
+
+  If a merge fails (conflict), stop and escalate:
+
+  ```
+  Merge conflict on PR #{N}. Resolve manually and re-run with --resume {sprint_id}.
+  ```
+
+- **Select**: Ask which PRs to merge, then merge those in order.
+- **Skip**: Leave PRs open for manual review.
+
+#### Step 4: Update Labels and Cleanup
+
+For each successfully merged PR:
+
+```bash
+gh issue edit {N} --repo {REPO} --remove-label "status:ready" --add-label "status:done"
+```
+
+For each successful but unmerged PR:
+
+```bash
+gh issue edit {N} --repo {REPO} --remove-label "status:ready" --add-label "status:review"
+```
+
+Clean up worktrees on target machines (best-effort):
+
+```bash
+ssh {machine} "cd {repo_path} && git worktree remove --force ~/.crane/tasks/{task_id}/worktree 2>/dev/null; rm -rf ~/.crane/tasks/{task_id}"
+```
+
+#### Step 5: Advance to Next Wave
+
+If more waves remain in the wave plan:
+
+1. Update sprint cache: `current_wave += 1`
+2. Display: `Wave {N} complete. Advancing to Wave {N+1}.`
+3. Loop back to DISPATCH Step 3 (fleet health check) with the next wave's issues.
+
+If all waves complete:
+
+```
+Orchestration complete.
+
+Sprint: {sprint_id}
+Waves: {total}
+Issues: {succeeded}/{total} succeeded
+PRs merged: {merged_count}
+```
+
+Remove sprint cache file.
+
+## Resume Logic (`--resume`)
+
+When `--resume <sprint_id>` is provided:
+
+1. **Read sprint cache**: Load `~/.crane/sprints/{sprint_id}.json` for dispatch metadata.
+
+   If file not found, stop: `Sprint {sprint_id} not found. Check ~/.crane/sprints/`
+
+2. **Query GitHub for actual state**: For all issues in the sprint's wave plan:
+
+   ```
+   crane_fleet_status({
+     repo: "{repo}",
+     issue_numbers: [{all_issue_numbers}]
+   })
+   ```
+
+3. **Query fleet for task state**: For all dispatched tasks:
+
+   ```
+   crane_fleet_status({
+     machine: "{machine}",
+     task_id: "{task_id}"
+   })
+   ```
+
+4. **Reconcile state** (GitHub wins over cache):
+   - PR merged -> issue is done, regardless of cache
+   - PR open -> task succeeded, resume at COLLECT
+   - Task running (PID alive) -> resume at MONITOR
+   - Task crashed (PID dead, no result.json) -> treat as failed
+   - No PR and no task running -> treat as failed
+
+5. **Determine resume point**:
+   - If all current wave PRs are merged -> advance to next wave DISPATCH
+   - If PRs are open but not merged -> resume at COLLECT
+   - If tasks are still running -> resume at MONITOR
+   - If all current wave tasks failed -> offer retry or skip, then advance
+
+6. Display reconciled state and resume point. Ask Captain for confirmation before continuing.
+
+## Notes
+
+Sprint cache schema is shown in DISPATCH Step 4. It is a **local performance cache**, NOT source of truth - GitHub is authoritative.
+
+- **mac23 excluded from worker pool**: The orchestrator host doesn't run workers by default to avoid resource contention.
+- **Fleet health checks before every wave**: Machines can go offline mid-sprint. Re-check before dispatching each wave.
+- **Exponential backoff**: Monitor polling starts at 30s intervals, backs off to 5min max when no changes detected. Resets to 30s when a status change is observed.
+- **GitHub as source of truth**: Resume reconstructs state from observable reality (GitHub PRs + fleet task status), not from the cache file. The cache accelerates resume but is never trusted over live state.
+- **Structured results**: Sprint workers write `result.json` to their worktree on completion. The fleet status tool reads this for structured status - no log scraping.
+- **Defense in depth**: Shell arguments are escaped in fleet-exec.sh and fleet-dispatch.ts. Issue bodies are passed via `gh issue view`, not inline.
+- **Single retry**: Failed tasks get at most one retry. Second failure is final.
+- **Merge order**: PRs are merged in dependency order (Wave 1 before Wave 2, within a wave: by issue number).

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -1,0 +1,405 @@
+# /sprint - Parallel Sprint Execution
+
+This command takes a set of pre-selected GitHub issue numbers, builds an optimal wave-based execution plan, and spawns parallel coding agents to implement them simultaneously using git worktrees for isolation.
+
+Works in any venture console repo. The prior step (human or planning agent) selects which issues go into the sprint. This command handles execution.
+
+> **When to use local vs fleet?** See `docs/fleet-decision-framework.md` for the decision matrix.
+
+## Arguments
+
+```
+/sprint <issue numbers> [--dry-run] [--parallel N]
+```
+
+- Issue numbers: space or comma-separated, `#` prefix optional
+- `--dry-run`: show wave plan only, do not execute
+- `--parallel N`: override max concurrent agents (default: machine-based lookup)
+
+Parse `$ARGUMENTS`:
+
+1. Split on whitespace and commas
+2. Strip `#` prefix from any token
+3. Extract `--dry-run` flag if present (remove from list)
+4. Extract `--parallel N` if present (remove both tokens from list)
+5. Remaining tokens are issue numbers (must be positive integers)
+
+If no issue numbers remain after parsing, display usage and stop:
+
+```
+Usage: /sprint <issue numbers> [--dry-run] [--parallel N]
+
+Examples:
+  /sprint 42 45 51              # execute issues 42, 45, 51
+  /sprint 42, 45 --dry-run      # show plan only
+  /sprint 42 45 --parallel 4    # override concurrency limit
+```
+
+Store: `ISSUE_NUMBERS` (array), `DRY_RUN` (bool), `MAX_CONCURRENT` (number or null).
+
+## Execution
+
+### Step 1: Detect Repo and Machine
+
+**Repo context:**
+
+Run these commands to detect context:
+
+```bash
+basename "$(pwd)"          # e.g., ke-console
+git remote get-url origin  # e.g., git@github.com:kidexpenses/ke-console.git
+```
+
+- `VENTURE_CODE`: basename of cwd minus `-console` suffix (e.g., `ke-console` -> `ke`)
+- `REPO`: extract `org/repo` from the git remote URL
+- `REPO_ROOT`: absolute path of the repo root (`git rev-parse --show-toplevel`)
+- `VERIFY_COMMAND`: read the repo's CLAUDE.md and extract the verify command (typically `npm run verify`)
+
+If not in a git repo or can't determine the remote, stop:
+
+```
+Not in a recognized repo. Run /sprint from a venture console directory.
+```
+
+**Machine resources:**
+
+If `--parallel N` was provided, set `MAX_CONCURRENT = N`.
+
+Otherwise, detect hostname:
+
+```bash
+hostname -s
+```
+
+Look up the default:
+
+| Hostname | Max Concurrent |
+| -------- | -------------- |
+| mac23    | 3              |
+| m16      | 3              |
+| mini     | 2              |
+| mbp27    | 2              |
+| think    | 1              |
+| (other)  | 2              |
+
+Display:
+
+```
+Sprint for {REPO}
+Machine: {hostname} | Max concurrent agents: {MAX_CONCURRENT}
+```
+
+### Step 2: Fetch and Analyze Issues
+
+For each issue number in `ISSUE_NUMBERS`, fetch via:
+
+```bash
+gh issue view {N} --repo {REPO} --json number,title,body,labels,state
+```
+
+**CRITICAL**: Make all `gh issue view` calls in parallel (multiple Bash tool calls in one message).
+
+For each issue, extract from labels:
+
+- **Priority**: `prio:*` label (P0/P1/P2/P3)
+- **Component**: `component:*` label
+- **Type**: `type:*` label
+- **Status**: `status:*` label
+
+Also extract from body:
+
+- **AC count**: count checkbox items (`- [ ]` lines)
+- **Body length**: word count of the issue body
+
+**Validation:**
+
+- If any issue does not exist or `gh issue view` fails, stop: `Issue #{N} not found in {REPO}. Aborting.`
+- If any issue has `state: closed`, stop: `Issue #{N} is closed. Remove it and re-run.`
+- If any issue lacks `status:ready`, warn (do not block): `Warning: Issue #{N} has status:{current} instead of status:ready.`
+
+Display issue summary table:
+
+```
+Issues:
+| #   | Title                | Priority | Type  | Component     | Status | ACs | Body Words |
+| --- | -------------------- | -------- | ----- | ------------- | ------ | --- | ---------- |
+| 45  | Fix balance calc     | P0       | bug   | ke-api        | ready  | 4   | 120        |
+| 42  | Add expense filter   | P1       | story | ke-app        | ready  | 6   | 280        |
+| 47  | Update docs          | P2       | tech  | -             | ready  | 2   | 45         |
+```
+
+### Step 3: Build Wave Plan
+
+**Extract explicit dependencies:**
+
+Scan each issue body (case-insensitive) for these patterns:
+
+- `depends on #N`
+- `blocked by #N`
+- `after #N`
+- `requires #N`
+
+Build a dependency graph. Only track dependencies within the sprint issue set. If a dependency references an issue NOT in the sprint, display a warning:
+
+```
+Warning: #{X} depends on #{Y}, which is not in this sprint. Treating as external (resolved).
+```
+
+**Schedule waves:**
+
+```
+available = issues with no unresolved in-sprint deps
+waves = []
+completed = set()
+
+while unscheduled issues remain:
+    wave = []
+    for issue in available (sorted: P0 first, then P1, P2, P3, then by issue number):
+        if len(wave) >= MAX_CONCURRENT: break
+        wave.append(issue)
+    waves.append(wave)
+    completed.update(wave issues)
+    recompute available (deps satisfied by completed set, not already scheduled)
+```
+
+If a cycle is detected (no available issues but unscheduled remain), stop:
+
+```
+Dependency cycle detected among issues: #{A}, #{B}, #{C}. Fix issue dependencies and re-run.
+```
+
+**Advisory warnings:**
+
+If two issues in the same wave share a `component:*` label, display:
+
+```
+Warning: Issues #{X} and #{Y} share component:{name} - may have file conflicts. Merge in listed order.
+```
+
+**Display the full wave plan:**
+
+```
+Wave Plan:
+
+Wave 1 (execute now):
+  #{45} [P0] Fix balance calc - component:ke-api
+  #{42} [P1] Add expense filter - component:ke-app
+  #{47} [P2] Update docs - (no component)
+
+Wave 2 (next run, after merging Wave 1):
+  #{48} [P1] Refactor auth - component:ke-api (depends on #45)
+
+Note: Wave 2 depends on Wave 1. Merge Wave 1 PRs before re-running.
+```
+
+If there is only one wave, omit the "next run" note.
+
+**If `DRY_RUN` is true: stop here.** Display "Dry run complete. Re-run without --dry-run to execute."
+
+### Step 4: Approval
+
+Ask the user using AskUserQuestion:
+
+**"Execute Wave 1? ({N} agents will be spawned)"**
+
+Options: "Execute" / "Abort"
+
+If Abort, stop: "Sprint aborted. Re-run with adjusted arguments."
+
+### Step 4b: Pre-flight CI Check
+
+Before creating worktrees, verify CI passes on `origin/main`. Create a temporary worktree, run verify, and clean up:
+
+```bash
+cd {REPO_ROOT} && git fetch origin main 2>&1
+git worktree add {REPO_ROOT}/.worktrees/_preflight origin/main 2>/dev/null
+cd {REPO_ROOT}/.worktrees/_preflight && npm ci --prefer-offline > /dev/null 2>&1 && {VERIFY_COMMAND}
+# Clean up regardless of result
+cd {REPO_ROOT} && git worktree remove --force {REPO_ROOT}/.worktrees/_preflight 2>/dev/null
+```
+
+If the verify command fails, display the failures and ask the Captain using AskUserQuestion:
+
+**"CI is broken on main. Fix first, or override and dispatch anyway?"**
+
+Options: "Fix first (abort)" / "Override and dispatch"
+
+- **Fix first**: Stop sprint. Display: `CI broken on main. Fix before dispatching.`
+- **Override**: Continue with a warning: `Warning: Dispatching despite CI failures on main. Agents may encounter pre-existing failures.`
+
+### Step 5: Set Up Worktrees
+
+**Check for active sprint:**
+
+```bash
+cat {REPO_ROOT}/.worktrees/.sprint.lock 2>/dev/null
+```
+
+If the lock file exists, read the PID from it. Check if the process is alive:
+
+```bash
+kill -0 {PID} 2>/dev/null
+```
+
+- If alive: stop with `Another sprint is active (PID {PID}). Wait for it to finish or kill that process first.`
+- If dead (stale lock): warn `Stale sprint lock found (PID {PID} is dead). Cleaning up and proceeding.` Remove the lock and any leftover worktrees.
+
+**Create lock:**
+
+```bash
+mkdir -p {REPO_ROOT}/.worktrees
+echo "$$" > {REPO_ROOT}/.worktrees/.sprint.lock
+```
+
+**Add `.worktrees/` to `.gitignore`** if not already present:
+
+Check if `.worktrees/` or `.worktrees` appears in `{REPO_ROOT}/.gitignore`. If not, append it:
+
+```bash
+echo '.worktrees/' >> {REPO_ROOT}/.gitignore
+```
+
+**Sync gate - fetch remote main:**
+
+Before creating any worktrees, fetch the latest remote main. Worktrees branch directly from `origin/main` to eliminate stale-base bugs and race conditions.
+
+```bash
+cd {REPO_ROOT} && git fetch origin main
+```
+
+**Create worktrees** for each Wave 1 issue:
+
+Branch naming: `{issue-number}-{slugified-title}` where slugified-title is the issue title lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 chars, trailing hyphens stripped.
+
+For each issue:
+
+```bash
+git worktree add {REPO_ROOT}/.worktrees/{issue-number} -b {branch-name} origin/main
+```
+
+This creates the worktree branching directly from the remote tracking ref - no dependency on local main being up to date.
+
+If the branch already exists, ask the user: reuse the existing branch or create with a `-2` suffix.
+
+If the worktree path already exists, remove it first:
+
+```bash
+git worktree remove --force {REPO_ROOT}/.worktrees/{issue-number} 2>/dev/null
+```
+
+**Install dependencies** in parallel (one Bash call per worktree, all in one message):
+
+```bash
+cd {REPO_ROOT}/.worktrees/{issue-number} && npm ci --prefer-offline 2>&1 | tail -5
+```
+
+Display: `Worktrees ready. Dependencies installed.`
+
+### Step 6: Execute Wave 1
+
+**Spawn all agents in ONE message** using the Task tool (`subagent_type: sprint-worker`).
+
+**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+
+Each agent receives only dynamic context. Static behavioral instructions (working directory discipline, verification workflow, result.json format, constraints) are defined in the `sprint-worker` agent definition at `.claude/agents/sprint-worker.md`.
+
+---
+
+**Coding Agent Prompt (dynamic context only):**
+
+```
+## Assignment
+- Issue: #{NUMBER} - {TITLE}
+- Worktree: {WORKTREE_PATH}
+- Branch: {BRANCH_NAME} (already checked out)
+- Repo: {REPO}
+- Verify command: {VERIFY_COMMAND}
+
+## Issue Details
+{FULL_ISSUE_BODY}
+```
+
+---
+
+**After all agents complete:**
+
+Parse each agent's final message:
+
+- Look for `PR_URL:` line to extract PR URL
+- Look for `FAILED:` line to detect failure
+- Extract files changed and verification status
+
+**For each successful PR:**
+
+Update the issue label from `status:ready` to `status:review`:
+
+```bash
+gh issue edit {NUMBER} --repo {REPO} --remove-label "status:ready" --add-label "status:review"
+```
+
+**For each failure:**
+
+Ask the user per failed issue using AskUserQuestion:
+
+**"Issue #{N} failed: {reason}. Retry or skip?"**
+
+Options: "Retry" / "Skip"
+
+- **Retry**: Remove the worktree (`git worktree remove --force ...`), fetch origin main, recreate fresh from `origin/main` (`git worktree add ... -b {branch} origin/main`), reinstall dependencies, and spawn one new `sprint-worker` agent with the same dynamic context prompt. After retry completes, process its result (update labels on success, report failure on second failure without further retry).
+- **Skip**: Mark as incomplete, continue.
+
+### Step 7: Report and Cleanup
+
+Display wave results:
+
+```
+Wave 1 Complete: {succeeded}/{total} issues
+
+| #   | Title              | Status  | PR    |
+| --- | ------------------ | ------- | ----- |
+| 45  | Fix balance calc   | SUCCESS | #67   |
+| 42  | Add expense filter | SUCCESS | #68   |
+| 47  | Update docs        | FAILED  | -     |
+```
+
+If there are remaining waves:
+
+```
+Remaining waves: {count} (issues: #{A}, #{B})
+Next: merge the PRs above, then run: /sprint {remaining issue numbers}
+```
+
+If all waves are done:
+
+```
+All sprint issues processed.
+```
+
+**Cleanup:**
+
+Remove worktrees and lock file:
+
+```bash
+git worktree remove --force {REPO_ROOT}/.worktrees/{N}   # for each issue
+rm -f {REPO_ROOT}/.worktrees/.sprint.lock
+rmdir {REPO_ROOT}/.worktrees 2>/dev/null                  # remove dir if empty
+```
+
+Branches are preserved (they back the open PRs).
+
+Done.
+
+---
+
+## Notes
+
+- **Single-wave execution**: Only Wave 1 is executed per run. User merges those PRs, then re-runs for Wave 2. This eliminates inter-wave state management and the dependency-branching problem.
+- **Worktrees inside repo**: `.worktrees/` lives at the repo root and is gitignored. No external directory management needed.
+- **Branches from origin/main**: Every branch starts from `origin/main` (fetched fresh before worktree creation). Eliminates stale-base bugs. PRs are independently reviewable.
+- **Orchestrator owns side effects**: Label updates happen here, not in the coding agents. Agents only push code and open PRs.
+- **Retry semantics**: Failed agents get a fresh worktree from `origin/main`. One retry max per failed issue. Second failure is final.
+- **Lock file**: Prevents concurrent sprint runs from colliding. PID-based with stale detection.
+- **Agent type**: All coding agents use `subagent_type: sprint-worker` via the Task tool. Static behavioral instructions live in `.claude/agents/sprint-worker.md`; only dynamic context (issue, worktree, branch, repo, verify command) is passed in the Task prompt.
+- **Structured results**: Sprint workers write `result.json` to the worktree root on completion (success or failure). The orchestrator can read this for structured status instead of parsing agent messages.
+- **Parallelism**: All Wave 1 agents launch in a single message for true parallel execution.
+- **No complexity estimation**: Issue metadata (AC count, body length) is displayed for human judgment. No S/M/L/XL heuristics.


### PR DESCRIPTION
## Summary
- Removed `qa-grade:*` label extraction from `.claude/commands/sprint.md`
- Removed `qa-grade:*` label extraction from `.claude/commands/orchestrate.md`
- QA grading system removed enterprise-wide - no downstream consumer

## Test plan
- [ ] Verify sprint.md no longer references qa-grade labels
- [ ] Verify orchestrate.md no longer references qa-grade labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)