### PR TITLE
fix(sync-docs): match current venturecrane org in upload-doc script

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -102,24 +102,30 @@ else
     # Venture-specific: determine from repo
     if [ -n "$GITHUB_REPOSITORY" ]; then
       case "$GITHUB_REPOSITORY" in
-        *venturecrane/crane-console*)
+        *venturecrane/crane-console*|*crane-console*)
           SCOPE="vc"
           ;;
-        *siliconcrane/sc-console*)
+        *venturecrane/sc-console*|*sc-console*)
           SCOPE="sc"
           ;;
-        *durganfieldguide/dfg-console*)
+        *venturecrane/dfg-console*|*dfg-console*)
           SCOPE="dfg"
           ;;
-        *smd-ventures/smd-console*)
+        *venturecrane/ke-console*|*ke-console*)
+          SCOPE="ke"
+          ;;
+        *venturecrane/smd-console*|*smd-console*)
           SCOPE="smd"
           ;;
-        *draftcrane/dc-console*)
+        *venturecrane/dc-console*|*dc-console*)
           SCOPE="dc"
+          ;;
+        *venturecrane/ss-console*|*ss-console*)
+          SCOPE="ss"
           ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console, smdurgan/smd-console"
+          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc,ss}-console"
           exit 1
           ;;
       esac


### PR DESCRIPTION
Fixes the recurring `Sync Docs to Context Worker` failure on main. The case statement was matching against obsolete org paths (`durganfieldguide/`, `siliconcrane/`, `smd-ventures/`, `draftcrane/`) that no longer exist; every venture repo is under `venturecrane/` today. Updated to cover all current ventures, mirroring `crane-console/scripts/upload-doc-to-context-worker.sh`. Same fix already opened in venturecrane/dfg-console#325, venturecrane/ke-console#235, venturecrane/dc-console#534, venturecrane/sc-console#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)