### PR TITLE
feat(ci): adopt enriched canonical PR template (#775 follow-up)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
-PR template enforces enterprise AC discipline. Every section is required
-unless explicitly marked optional. Reviewers: do not approve a PR that
-leaves the "Acceptance criteria status" or "Linked issue" sections blank
-or templated. Auto-ticking on merge is documented in
+Enterprise PR template. Every section is required unless explicitly marked
+optional. Reviewers: do not approve a PR that leaves the "Acceptance
+criteria status" or "Linked issue" sections blank or templated. AC
+auto-ticking on merge is documented at:
 https://github.com/venturecrane/crane-console/blob/main/docs/runbooks/ac-tick-workflow-rollout.md
 -->
 
@@ -40,8 +40,8 @@ N/A, or deferred. Reviewers approve based on this table.
 <!--
 Only fill this section if you are deferring one or more ACs. Each deferred AC
 needs a rationale and a follow-on issue. The `scope-deferred` label is what
-unblocks the TODO-in-source CI check — without this section filled in, that
-check will fail. See the [AC enforcement runbook](https://github.com/venturecrane/crane-console/blob/main/docs/runbooks/ac-tick-workflow-rollout.md).
+unblocks any TODO-in-source CI check — without this section filled in, that
+check will fail.
 -->
 
 - **AC:** _(verbatim text)_
@@ -52,5 +52,36 @@ check will fail. See the [AC enforcement runbook](https://github.com/venturecran
 
 - [ ] `npm run verify` passes
 - [ ] _(feature-specific manual verification)_
+
+## Security Checklist
+
+<!--
+Pause and check each item. Self-attestation is the floor; the Semgrep gate
+and Secret Detection workflow are the belt-and-suspenders.
+-->
+
+- [ ] No secrets in code or comments
+- [ ] No PII exposed in frontend responses
+- [ ] Input validation on new endpoints
+- [ ] Parameterized queries for any SQL (use `.bind()`)
+- [ ] Auth required on new endpoints
+- [ ] No internal IDs that enable enumeration
+
+## Feature Impact
+
+<!--
+Does this PR remove, disable, or change any existing user-facing
+functionality?
+
+Write "None" if no existing features are affected.
+Write "Authorized — #{directive}" if the Captain approved the removal/change.
+If neither applies, STOP — fetch `crane_doc('global', 'guardrails.md')`.
+-->
+
+**Feature impact:** None
+
+## Deployment Notes
+
+<!-- Schema migrations, env vars, secret rotations, manual ops? Leave blank if standard deploy. -->
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Replaces the venture's existing PR template wholesale with the 8-section enterprise canonical from crane-console. Net change:

- **Adds:** Security Checklist (defense-in-depth), Feature Impact (pairs with the "never remove features without Captain directive" guardrail), Deployment Notes (catches schema/env/secret/manual-ops gotchas)
- **Drops:** "Related Issues" (superseded by explicit "Linked issue") and "Changes" (redundant with Summary + AC evidence)
- **Standardizes:** Section ordering and the AC-status section text across the enterprise

Captain authorized this enrichment after reviewing the original cascade (crane-console#775).

## Linked issue

Refs venturecrane/crane-console#775

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Template matches enterprise canonical | met | This commit |

## Test plan

- [ ] On merge: no behavioral change (template only affects new PRs going forward)
- [ ] Future PR: `Acceptance criteria status` section renders correctly and gets parsed by the AC-tick workflow

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints (no endpoints touched)
- [x] Parameterized queries for any SQL (no SQL touched)
- [x] Auth required on new endpoints (no endpoints touched)
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None — template-only change.

## Deployment Notes

No deploy steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
