### PR TITLE
fix: restore contact-form sender to contact@smdurgan.com

### DIFF
--- a/smd-web/functions/api/contact.ts
+++ b/smd-web/functions/api/contact.ts
@@ -13,7 +13,7 @@ interface ContactPayload {
 
 const ALLOWED_ORIGINS = ['https://smdurgan.com', 'https://www.smdurgan.com']
 const TO_EMAIL = 'smdurgan@smdurgan.com'
-const FROM_EMAIL = 'SMDurgan, LLC <contact@smd.services>'
+const FROM_EMAIL = 'SMDurgan, LLC <contact@smdurgan.com>'
 const CONTROL_CHAR_RE = /[\r\n\0]/
 
 function hasControlChars(value: string): boolean {


### PR DESCRIPTION
## What
Restores `smd-web/functions/api/contact.ts` FROM to `contact@smdurgan.com`, reverting the sender change from #34.

## Why — #34 broke the production contact form
smd-console's `RESEND_API_KEY` authenticates to a **different Resend account** than the one that owns `smd.services`, so sending from `contact@smd.services` fails and the live form began returning **HTTP 500** (verified via test POST; no send record on the smd.services account, whose key shows "last used 6 days ago"). `smdurgan.com` is verified on smd-console's account, so restoring it fixes the form.

## Kept intentionally
The brace-expansion audit-gate `overrides` from #34 stay — they unblocked a 3-day CI freeze and are unrelated to the sender.

## Follow-up
Resend free-tier consolidation to be re-scoped around the real multi-account topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)